### PR TITLE
Fixed Windows support

### DIFF
--- a/cpp/src/json_parser.h
+++ b/cpp/src/json_parser.h
@@ -166,7 +166,7 @@ void json_increment_context(JsonParseContext& context) {
 
 INTERNAL inline
 void json_eat_whitespace(JsonParseContext& context) {
-    while ( is_whitespace(context.buffer[context.pos]) ) {
+    while ( context.pos < context.buffer.size() && is_whitespace(context.buffer[context.pos]) ) {
         json_increment_context(context);
     }
 }

--- a/cpp/src/open_browser.h
+++ b/cpp/src/open_browser.h
@@ -9,10 +9,16 @@
 #ifdef __linux__
 #include <cstring>
 #elif defined(macintosh) || defined(Macintosh) || defined(__APPLE__) && defined(__MACH__)
+
 #include <CoreFoundation/CFBundle.h>
 #include <ApplicationServices/ApplicationServices.h>
-#elif defined(_MSC_VER) && !defined(__INTEL_COMPILER)
-#include <shellapi.h>
+
+#elif defined(_WIN32) || defined(__WIN32__) || defined(__WINDOWS__)
+
+#include <ShlObj.h>
+#include <winbase.h>
+#include <Shellapi.h>
+
 #endif
 
 #ifdef TEST_OPEN_BROWSER
@@ -56,7 +62,7 @@ void open_browser(const URL& url)
     );
     LSOpenCFURLRef(cf_url,0);
     CFRelease(cf_url);
-#elif defined(_MSC_VER) && !defined(__INTEL_COMPILER)
+#elif defined(_WIN32) || defined(__WIN32__) || defined(__WINDOWS__)
     ShellExecuteA(NULL, "open", url_str.c_str(), NULL, NULL, SW_SHOWNORMAL);
 #endif
 

--- a/cpp/src/tiny_web_server.h
+++ b/cpp/src/tiny_web_server.h
@@ -3,14 +3,14 @@
 
 #include <string>
 
-static char responseOk[] = "HTTP/1.0 200 OK\r\n"
-                           "Content-Type: text/plain\r\n"
-                           "\r\n"
-                           "Ok. You may close this tab and return to the shell.\r\n";
-static char responseErr[] = "HTTP/1.0 400 Bad Request\r\n"
-                            "Content-Type: text/plain\r\n"
-                            "\r\n"
-                            "Bad Request\r\n";
+static const char responseOk[] = "HTTP/1.0 200 OK\r\n"
+                                 "Content-Type: text/plain\r\n"
+                                 "\r\n"
+                                 "Ok. You may close this tab and return to the shell.\r\n";
+static const char responseErr[] = "HTTP/1.0 400 Bad Request\r\n"
+                                  "Content-Type: text/plain\r\n"
+                                  "\r\n"
+                                  "Bad Request\r\n";
 
 // This is a specialised web server type functionality
 // that waits on IBM to call us back.


### PR DESCRIPTION
[tiny_web_{client,server}.cpp] Use `ZeroMemory` instead of `memset`; remove global `#define`s in favour of local `ifdef`s to `closesocket`|`close`, `recv`|`read`, and `send`|`write; [open_browser.h] Don't bring in whole <Windows.h> just include 3 specific headers; [json_parser.h] Bounds check in `json_eat_whitespace` to avoid overrun